### PR TITLE
ensure the creation of lvm device nodes, fixing issues on some devices

### DIFF
--- a/encryption.boot
+++ b/encryption.boot
@@ -79,6 +79,7 @@ command -v cryptsetup > /dev/null && test -f /etc/crypttab && {
     command -v lvm > /dev/null && {
         log "Activating LVM devices for LUKS (if any exist)..."
         lvm vgchange --sysinit -aay
+        lvmvgscan --mknodes
     }
 }
 


### PR DESCRIPTION
I had an issue with device mapping on a thinkpad r400. the /dev/mapper/* entries where not created, but the /dev/dm-* where. this fixed the issue and does not appear to have side effects on working devices.